### PR TITLE
fix: alb to update when security groups change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,9 +78,10 @@ resource "aws_lb" "default" {
   internal           = var.internal
   load_balancer_type = "application"
 
-  security_groups = compact(
-    concat(var.security_group_ids, [join("", aws_security_group.default.*.id)]),
-  )
+  security_groups = flatten([
+    var.security_group_ids,
+    try([aws_security_group.default[0].id], [])
+  ])
 
   subnets                          = var.subnet_ids
   enable_cross_zone_load_balancing = var.cross_zone_load_balancing_enabled


### PR DESCRIPTION
Fixes an issue where Terraform will not recognize that the ALB should be updated when its security groups have changed.

